### PR TITLE
Default new sessions to GLM 5.3 Flash

### DIFF
--- a/openhack/config.py
+++ b/openhack/config.py
@@ -20,7 +20,7 @@ def _normalize_user_config(data: dict) -> dict:
     if data.get("provider") not in _REMOVED_PROVIDER_IDS:
         return data
     normalized = dict(data)
-    normalized.update({"provider": "openhack", "model": "glm-5.2"})
+    normalized.update({"provider": "openhack", "model": "glm-5.3-flash"})
     return normalized
 
 
@@ -99,7 +99,7 @@ class Settings(BaseSettings):
     openhack_api_key: Optional[str] = None
     openhack_base_url: str = ""
     openhack_app_url: str = ""
-    openhack_model_id: str = "glm-5.2"
+    openhack_model_id: str = "glm-5.3-flash"
     # Throughput-first OpenRouter routing for hosted OpenHack inference.
     fast_mode: bool = False
     # Rotating contextual guidance on the TUI landing screen.

--- a/openhack/setup.py
+++ b/openhack/setup.py
@@ -72,7 +72,7 @@ PROVIDERS = [
         "key_env": "OPENHACK_API_KEY",
         # key_url is built dynamically from settings.openhack_app_url at display time.
         "models": [],
-        "default_model": "glm-5.2",
+        "default_model": "glm-5.3-flash",
     },
 ]
 
@@ -493,7 +493,7 @@ async def _run_first_time_onboarding() -> bool:
     _html(f"  {GREEN}✓{EGREEN} Connected to OpenHack")
     _html(f"  {GREEN}✓{EGREEN} Inference verified")
 
-    model_id = "glm-5.2"
+    model_id = "glm-5.3-flash"
 
     new_cfg = {
         "provider": "openhack",
@@ -868,7 +868,7 @@ async def _connect_openhack(
         _html(f"  {YELLOW}⚠{EYELLOW} Could not verify this connection.")
         return False
 
-    model_id = "glm-5.2"
+    model_id = "glm-5.3-flash"
     new_cfg = {
         "provider": "openhack",
         "model": model_id,

--- a/openhack/tui.py
+++ b/openhack/tui.py
@@ -305,7 +305,7 @@ class _PlaceholderProcessor(Processor):
 
 
 
-PROVIDER_DEFAULTS = {"openhack": "glm-5.2"}
+PROVIDER_DEFAULTS = {"openhack": "glm-5.3-flash"}
 
 CHAT_SYSTEM_PROMPT = (
     "You are OpenHack, a security-focused AI assistant embedded in the OpenHack CLI. "
@@ -1605,7 +1605,7 @@ class OpenHackApp:
                 ),
             )
             if replacement == "openhack":
-                replacement_model = "glm-5.2"
+                replacement_model = "glm-5.3-flash"
             else:
                 resolved = provider_registry.resolve(replacement)
                 replacement_model = resolved.model if resolved else ""
@@ -2664,7 +2664,7 @@ class OpenHackApp:
             ("class:input.box", "  "),
             ("class:input.model.agent", cwd),
             ("class:input.model.sep", " · "),
-            ("class:input.model.name", self.model or "glm-5.2"),
+            ("class:input.model.name", self.model or "glm-5.3-flash"),
             (
                 "class:input.model.provider",
                 f"  {self.provider}"
@@ -4753,7 +4753,7 @@ class OpenHackApp:
             self.last_status_line = f"connection failed: {provider_id} is not authenticated"
             return False
         if provider_id == "openhack":
-            model_id = "glm-5.2"
+            model_id = "glm-5.3-flash"
             provider_label = label or "OpenHack"
         else:
             resolved = provider_registry.resolve(provider_id)
@@ -4919,7 +4919,7 @@ class OpenHackApp:
         remove_credential(provider_id)
         if self.provider == provider_id:
             self.provider = "openhack"
-            self.model = settings.openhack_model_id or "glm-5.2"
+            self.model = settings.openhack_model_id or "glm-5.3-flash"
             save_user_config({"provider": self.provider, "model": self.model})
         self.last_status_line = f"disconnected {provider_id}"
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -47,7 +47,7 @@ class TestLoadSaveConfig:
             loaded = load_user_config()
 
         assert loaded["provider"] == "openhack"
-        assert loaded["model"] == "glm-5.2"
+        assert loaded["model"] == "glm-5.3-flash"
         assert resolve_provider("opencode") == "openhack"
 
 

--- a/tests/test_first_time_onboarding.py
+++ b/tests/test_first_time_onboarding.py
@@ -34,7 +34,7 @@ async def test_openhack_onboarding_verifies_and_defaults_to_glm(monkeypatch):
         "openhack.agents.llm.fetch_available_models",
         lambda **kwargs: [
             "grok-4.5",
-            "glm-5.2",
+                "glm-5.3-flash",
             "kimi-k2.5",
             "new-hosted-model",
         ],
@@ -42,7 +42,7 @@ async def test_openhack_onboarding_verifies_and_defaults_to_glm(monkeypatch):
 
     assert await setup._run_first_time_onboarding() is True
     assert saved[-1]["provider"] == "openhack"
-    assert saved[-1]["model"] == "glm-5.2"
+    assert saved[-1]["model"] == "glm-5.3-flash"
     assert saved[-1]["openhack_model_id"] == "glm-5.2"
     assert saved[-1]["onboarding_version"] == 1
     assert titles == ["Connect a provider", "Connect OpenHack"]

--- a/tests/test_first_time_onboarding.py
+++ b/tests/test_first_time_onboarding.py
@@ -34,7 +34,7 @@ async def test_openhack_onboarding_verifies_and_defaults_to_glm(monkeypatch):
         "openhack.agents.llm.fetch_available_models",
         lambda **kwargs: [
             "grok-4.5",
-                "glm-5.3-flash",
+            "glm-5.3-flash",
             "kimi-k2.5",
             "new-hosted-model",
         ],
@@ -43,7 +43,7 @@ async def test_openhack_onboarding_verifies_and_defaults_to_glm(monkeypatch):
     assert await setup._run_first_time_onboarding() is True
     assert saved[-1]["provider"] == "openhack"
     assert saved[-1]["model"] == "glm-5.3-flash"
-    assert saved[-1]["openhack_model_id"] == "glm-5.2"
+    assert saved[-1]["openhack_model_id"] == "glm-5.3-flash"
     assert saved[-1]["onboarding_version"] == 1
     assert titles == ["Connect a provider", "Connect OpenHack"]
 


### PR DESCRIPTION
Use GLM 5.3 Flash for new hosted sessions, setup, and fallback defaults. Persisted explicit model choices and per-agent overrides remain unchanged. Hosted routing prefers Merge with emergency OpenRouter fallback. Validation: config tests passed.